### PR TITLE
bcryptを入れたGemfileでbuildできるように変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ rails/config/master.key
 
 .env
 python/.env
+
+python/app/data

--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -23,7 +23,7 @@ gem "jbuilder"
 # gem "kredis"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
-# gem "bcrypt", "~> 3.1.7"
+gem "bcrypt", "~> 3.1.7"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]

--- a/rails/Gemfile.lock
+++ b/rails/Gemfile.lock
@@ -76,6 +76,7 @@ GEM
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.3)
     base64 (0.3.0)
+    bcrypt (3.1.20)
     benchmark (0.4.1)
     bigdecimal (3.2.3)
     bindex (0.8.1)
@@ -291,6 +292,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap
   brakeman
   capybara


### PR DESCRIPTION
rails/Gemfile:24 でコメントアウトされていた gem "bcrypt", "~> 3.1.7" を有効化し、アプリの依存関係として追加しました。
それに合わせて rails/Gemfile.lock:79 と rails/Gemfile.lock:295 を更新し、bcrypt (3.1.20) と bcrypt (~> 3.1.7) を記録して Bundler の “frozen” エラーを解消しました。