### PR TITLE
リアクションボタンを押したときの、500エラーを解消

### DIFF
--- a/rails/app/controllers/api/v1/posts_controller.rb
+++ b/rails/app/controllers/api/v1/posts_controller.rb
@@ -102,8 +102,7 @@ module Api
           # リアクションを＋1するように、Post_Reactionsテーブルにレコードを追加
           reaction = post.post_reactions.find_or_initialize_by(
             reaction_id: reaction_id,
-            user_id: user_id,
-            topic_id: post.topic_id
+            user_id: user_id
           )
 
           if reaction.persisted?
@@ -117,8 +116,7 @@ module Api
           # リアクションを－1するように、Post_Reactionsテーブルからレコードを削除
           reaction = post.post_reactions.find_by(
             reaction_id: reaction_id,
-            user_id: user_id,
-            topic_id: post.topic_id
+            user_id: user_id
           )
 
           unless reaction

--- a/rails/app/controllers/api/v1/posts_controller.rb
+++ b/rails/app/controllers/api/v1/posts_controller.rb
@@ -6,6 +6,7 @@ module Api
 
       # GET /api/v1/posts
       def index
+        @current_user_id = params[:user_id].presence&.to_i
         posts = Post.order(created_at: :desc)
         render json: posts.map { |p| serialize_post(p) }
       end
@@ -165,6 +166,7 @@ module Api
           content:    post.content,
           image_url:  build_image_url(post.image),
           num_reactions: get_num_reactions(post),
+          reacted_reaction_ids: @current_user_id ? post.post_reactions.where(user_id: @current_user_id).pluck(:reaction_id) : [],
           created_at: post.created_at,
           updated_at: post.updated_at
         }

--- a/rails/config/initializers/cors.rb
+++ b/rails/config/initializers/cors.rb
@@ -2,7 +2,7 @@
 allowed_origins = [
   'http://localhost:3000',
   'http://127.0.0.1:3000',
-  'http://192.168.0.105:3000',
+  'http://172.21.0.1:3000',
   # 'https://localhost:3000', # Next.js を https で動かす場合は追加
   ENV.fetch('FRONTEND_ORIGIN', nil)
 ].compact


### PR DESCRIPTION
- 再読み込みしたとき、押した判定がないから再度incrementがtrue or falseになって、422エラーが発生するバグが残ってる

- 存在しないpost_reactions テーブルのtopic_idカラムへの参照を削除して、500エラーを解消
